### PR TITLE
Track searched runes and bail if revisiting

### DIFF
--- a/anagrambler.go
+++ b/anagrambler.go
@@ -29,12 +29,18 @@ func search(prefix string, postfix string, path *node, results map[*node]bool) {
 	if len(path.words) > 0 {
 		if !results[path] {
 			results[path] = true
+		} else {
+			return
 		}
 	}
+	searched_runes := make(map[rune]bool)
 	for i, letter := range postfix {
 		_, nodeExists := path.children[string(letter)]
-		if nodeExists {
+		if nodeExists && !searched_runes[letter] {
 			search(string(letter), postfix[i+1:], path.children[string(letter)], results)
+		}
+		if !searched_runes[letter] {
+			searched_runes[letter] = true
 		}
 	}
 }


### PR DESCRIPTION
If we've already search()ed for a rune, all of its results will be duplicates.
So we can fail early on that. (In other words, if our search string has
duplicate runes, we can skip over the results from the duplicated runes.)

Also, if we're revisiting a node for any other reason, we've already traversed
all results below it, so we can return early in that case.

This patch leads to staggering, almost incomprehensible speedups.
