### PR TITLE
Add search filter parameter

### DIFF
--- a/anagrambler_test.go
+++ b/anagrambler_test.go
@@ -13,14 +13,10 @@ func TestKnownOutput(t *testing.T) {
 
 	searchWord := "honorificabilitudinitatibus"
 
-	results := anagrambler.Search(trie, searchWord)
+	results := anagrambler.Search(trie, searchWord, "")
 
-	counter := 0
-	for path := range results {
-		counter += len(path.Words)
-	}
-	if counter != 9083 {
-		t.Error("Expected 9083 words, got ", counter)
+	if len(results) != 9083 {
+		t.Error("Expected 9083 words, got ", len(results))
 	}
 }
 
@@ -34,6 +30,6 @@ func BenchmarkAnagrambler(b *testing.B) {
 	b.ResetTimer()
 
 	for counter := 0; counter < b.N; counter++ {
-		anagrambler.Search(trie, searchWord)
+		anagrambler.Search(trie, searchWord, "")
 	}
 }

--- a/cmd/anagrambler/main.go
+++ b/cmd/anagrambler/main.go
@@ -12,16 +12,23 @@ func main() {
 
 	anagrambler.LoadDict(trie, "go-dict.txt")
 
-	searchWord := os.Args[1]
+	if len(os.Args) > 1 {
+		searchWord := os.Args[1]
 
-	results := anagrambler.Search(trie, searchWord)
+		filter := ""
 
-	count := 0
+		if len(os.Args) == 3 {
+			filter = os.Args[2]
+		}
 
-	for path := range results {
-		fmt.Println(path.Words)
-		count += len(path.Words)
+		results := anagrambler.Search(trie, searchWord, filter)
+
+		fmt.Println("Number of anagrams:", len(results))
+
+		for _, anagram := range results {
+			fmt.Println(anagram)
+		}
+	} else {
+		fmt.Println("No search string specified")
 	}
-
-	fmt.Println("Number of anagrams:", count)
 }


### PR DESCRIPTION
This will let us constrain the returned results to just the ones
containing a filter string.

The filtering happens in two phases: first, as we traverse the trie and
encounter the first character in the filter, we remove it in the
recursive search call for that character. We repeat this, until the filter
is empty. At that point, any node we encounter has satisfied the first
phase of the filter (since its full path contains all of the characters
in the filter, though not necessarily in the correct order).

If, while traversing, we encounter a letter that is alphabetically later
than the next character in the filter, then we know this node and all
its descendents will not satisfy the filter (because the next character
in the filter is missing from them). So at that point we abandon that
branch of the trie by returning from the recursion.

After we've finished traversing the trie, we then iterate through all of
the collected results, and keep only those which contain exactly the
filter string -- i.e. we discard any anagrams where the characters in
the filter string are not in the right order, next to each other, as a
proper substring.

At that point, the list of result anagrams is returned.

I also reworked the main function to not crash if the program isn't
supplied any arguments, and to use the filter if it is supplied.
