### PR TITLE
Refactor API

### DIFF
--- a/anagrambler.go
+++ b/anagrambler.go
@@ -35,13 +35,13 @@ func newNode() *node {
 	}
 }
 
-func Open(filepath string) *Trie {
+func Open(filepath string) (*Trie, error) {
 	t := NewTrie()
 
 	data, err := ioutil.ReadFile(filepath)
 
 	if err != nil {
-		panic(err)
+		return nil, err
 	}
 
 	words := strings.Split(string(data), "\n")
@@ -51,7 +51,7 @@ func Open(filepath string) *Trie {
 		t.Add(word)
 	}
 
-	return t
+	return t, nil
 }
 
 func (t *Trie) Add(word string) {

--- a/anagrambler.go
+++ b/anagrambler.go
@@ -13,9 +13,19 @@ func sortedLower(w string) string {
 	return strings.Join(s, "")
 }
 
+type Trie struct {
+	root *Node
+}
+
 type Node struct {
 	Words    []string
 	Children map[rune]*Node
+}
+
+func NewTrie() *Trie {
+	return &Trie{
+		root: NewNode(),
+	}
 }
 
 func NewNode() *Node {
@@ -25,7 +35,7 @@ func NewNode() *Node {
 	}
 }
 
-func LoadDict(root *Node, filepath string) {
+func LoadDict(t *Trie, filepath string) {
 	data, err := ioutil.ReadFile(filepath)
 
 	if err != nil {
@@ -36,12 +46,12 @@ func LoadDict(root *Node, filepath string) {
 	words = words[:len(words)-1]
 
 	for _, word := range words {
-		AddWord(root, word)
+		AddWord(t, word)
 	}
 }
 
-func AddWord(root *Node, word string) {
-	path := root
+func AddWord(t *Trie, word string) {
+	path := t.root
 
 	for _, letter := range sortedLower(word) {
 		if path.Children[letter] == nil {
@@ -52,10 +62,10 @@ func AddWord(root *Node, word string) {
 	path.Words = append(path.Words, word)
 }
 
-func Search(root *Node, text string, filter string) []string {
+func Search(t *Trie, text string, filter string) []string {
 	results := make(map[*Node]bool)
 
-	search(root, sortedLower(text), sortedLower(filter), results)
+	search(t.root, sortedLower(text), sortedLower(filter), results)
 
 	filteredResults := make([]string, 0)
 

--- a/anagrambler.go
+++ b/anagrambler.go
@@ -6,12 +6,7 @@ import (
 	"strings"
 )
 
-func sortedLower(w string) string {
-	w = strings.ToLower(w)
-	s := strings.Split(w, "")
-	sort.Strings(s)
-	return strings.Join(s, "")
-}
+// Types
 
 type Trie struct {
 	root *node
@@ -22,16 +17,11 @@ type node struct {
 	Children map[rune]*node
 }
 
+// Exported functions
+
 func NewTrie() *Trie {
 	return &Trie{
 		root: newNode(),
-	}
-}
-
-func newNode() *node {
-	return &node{
-		Words:    make([]string, 0, 1),
-		Children: make(map[rune]*node),
 	}
 }
 
@@ -53,6 +43,8 @@ func Open(filepath string) (*Trie, error) {
 
 	return t, nil
 }
+
+// Exported Methods
 
 func (t *Trie) Add(word string) {
 	path := t.root
@@ -82,6 +74,22 @@ func (t *Trie) Search(text string, filter string) []string {
 	}
 
 	return filteredResults
+}
+
+// Unexported Functions
+
+func newNode() *node {
+	return &node{
+		Words:    make([]string, 0, 1),
+		Children: make(map[rune]*node),
+	}
+}
+
+func sortedLower(w string) string {
+	w = strings.ToLower(w)
+	s := strings.Split(w, "")
+	sort.Strings(s)
+	return strings.Join(s, "")
 }
 
 func search(n *node, text string, filter string, results map[*node]bool) {

--- a/anagrambler.go
+++ b/anagrambler.go
@@ -35,7 +35,7 @@ func newNode() *node {
 	}
 }
 
-func LoadDict(filepath string) *Trie {
+func Open(filepath string) *Trie {
 	t := NewTrie()
 
 	data, err := ioutil.ReadFile(filepath)
@@ -48,13 +48,13 @@ func LoadDict(filepath string) *Trie {
 	words = words[:len(words)-1]
 
 	for _, word := range words {
-		t.AddWord(word)
+		t.Add(word)
 	}
 
 	return t
 }
 
-func (t *Trie) AddWord(word string) {
+func (t *Trie) Add(word string) {
 	path := t.root
 
 	for _, letter := range sortedLower(word) {

--- a/anagrambler.go
+++ b/anagrambler.go
@@ -14,24 +14,24 @@ func sortedLower(w string) string {
 }
 
 type Trie struct {
-	root *Node
+	root *node
 }
 
-type Node struct {
+type node struct {
 	Words    []string
-	Children map[rune]*Node
+	Children map[rune]*node
 }
 
 func NewTrie() *Trie {
 	return &Trie{
-		root: NewNode(),
+		root: newNode(),
 	}
 }
 
-func NewNode() *Node {
-	return &Node{
+func newNode() *node {
+	return &node{
 		Words:    make([]string, 0, 1),
-		Children: make(map[rune]*Node),
+		Children: make(map[rune]*node),
 	}
 }
 
@@ -55,7 +55,7 @@ func AddWord(t *Trie, word string) {
 
 	for _, letter := range sortedLower(word) {
 		if path.Children[letter] == nil {
-			path.Children[letter] = NewNode()
+			path.Children[letter] = newNode()
 		}
 		path = path.Children[letter]
 	}
@@ -63,7 +63,7 @@ func AddWord(t *Trie, word string) {
 }
 
 func Search(t *Trie, text string, filter string) []string {
-	results := make(map[*Node]bool)
+	results := make(map[*node]bool)
 
 	search(t.root, sortedLower(text), sortedLower(filter), results)
 
@@ -80,7 +80,7 @@ func Search(t *Trie, text string, filter string) []string {
 	return filteredResults
 }
 
-func search(n *Node, text string, filter string, results map[*Node]bool) {
+func search(n *node, text string, filter string, results map[*node]bool) {
 	// Record any words stored at this node
 	// Only record acronyms after the filter has been satisfied
 	if filter == "" && len(n.Words) > 0 {

--- a/anagrambler.go
+++ b/anagrambler.go
@@ -35,7 +35,9 @@ func newNode() *node {
 	}
 }
 
-func LoadDict(t *Trie, filepath string) {
+func LoadDict(filepath string) *Trie {
+	t := NewTrie()
+
 	data, err := ioutil.ReadFile(filepath)
 
 	if err != nil {
@@ -46,11 +48,13 @@ func LoadDict(t *Trie, filepath string) {
 	words = words[:len(words)-1]
 
 	for _, word := range words {
-		AddWord(t, word)
+		t.AddWord(word)
 	}
+
+	return t
 }
 
-func AddWord(t *Trie, word string) {
+func (t *Trie) AddWord(word string) {
 	path := t.root
 
 	for _, letter := range sortedLower(word) {
@@ -62,7 +66,7 @@ func AddWord(t *Trie, word string) {
 	path.Words = append(path.Words, word)
 }
 
-func Search(t *Trie, text string, filter string) []string {
+func (t *Trie) Search(text string, filter string) []string {
 	results := make(map[*node]bool)
 
 	search(t.root, sortedLower(text), sortedLower(filter), results)

--- a/anagrambler_test.go
+++ b/anagrambler_test.go
@@ -26,7 +26,7 @@ var (
 		{"go-dict.txt", "Lopadotemachoselachogaleokranioleipsanodrimhypotrimmatosilphioparaomelitokatakechymenokichlepikossyphophattoperisteralektryonoptekephalliokigklopeleiolagoiosiraiobaphetraganopterygon", "", 112436},
 		{"go-dict.txt", "Lopadotemachoselachogaleokranioleipsanodrimhypotrimmatosilphioparaomelitokatakechymenokichlepikossyphophattoperisteralektryonoptekephalliokigklopeleiolagoiosiraiobaphetraganopterygon", "pet", 342},
 	}
-	testTrie = anagrambler.LoadDict(testData[0].dict)
+	testTrie = anagrambler.Open(testData[0].dict)
 )
 
 func testAnagramCount(t *testing.T, d dataItem) {
@@ -53,7 +53,7 @@ func benchmarkFillTrie(b *testing.B, dictPath string) {
 		trie := anagrambler.NewTrie()
 
 		for _, word := range words {
-			trie.AddWord(word)
+			trie.Add(word)
 		}
 	}
 }

--- a/anagrambler_test.go
+++ b/anagrambler_test.go
@@ -26,8 +26,17 @@ var (
 		{"go-dict.txt", "Lopadotemachoselachogaleokranioleipsanodrimhypotrimmatosilphioparaomelitokatakechymenokichlepikossyphophattoperisteralektryonoptekephalliokigklopeleiolagoiosiraiobaphetraganopterygon", "", 112436},
 		{"go-dict.txt", "Lopadotemachoselachogaleokranioleipsanodrimhypotrimmatosilphioparaomelitokatakechymenokichlepikossyphophattoperisteralektryonoptekephalliokigklopeleiolagoiosiraiobaphetraganopterygon", "pet", 342},
 	}
-	testTrie = anagrambler.Open(testData[0].dict)
+	testTrie *anagrambler.Trie
 )
+
+func init() {
+	var err error
+	testTrie, err = anagrambler.Open(testData[0].dict)
+
+	if err != nil {
+		panic(err)
+	}
+}
 
 func testAnagramCount(t *testing.T, d dataItem) {
 	results := testTrie.Search(d.input, d.filter)

--- a/anagrambler_test.go
+++ b/anagrambler_test.go
@@ -26,7 +26,7 @@ var (
 		{"go-dict.txt", "Lopadotemachoselachogaleokranioleipsanodrimhypotrimmatosilphioparaomelitokatakechymenokichlepikossyphophattoperisteralektryonoptekephalliokigklopeleiolagoiosiraiobaphetraganopterygon", "", 112436},
 		{"go-dict.txt", "Lopadotemachoselachogaleokranioleipsanodrimhypotrimmatosilphioparaomelitokatakechymenokichlepikossyphophattoperisteralektryonoptekephalliokigklopeleiolagoiosiraiobaphetraganopterygon", "pet", 342},
 	}
-	testTrie = anagrambler.NewNode()
+	testTrie = anagrambler.NewTrie()
 )
 
 func init() {
@@ -54,7 +54,7 @@ func benchmarkFillTrie(b *testing.B, dictPath string) {
 	words = words[:len(words)-1]
 
 	for counter := 0; counter < b.N; counter++ {
-		trie := anagrambler.NewNode()
+		trie := anagrambler.NewTrie()
 
 		for _, word := range words {
 			anagrambler.AddWord(trie, word)

--- a/anagrambler_test.go
+++ b/anagrambler_test.go
@@ -26,15 +26,11 @@ var (
 		{"go-dict.txt", "Lopadotemachoselachogaleokranioleipsanodrimhypotrimmatosilphioparaomelitokatakechymenokichlepikossyphophattoperisteralektryonoptekephalliokigklopeleiolagoiosiraiobaphetraganopterygon", "", 112436},
 		{"go-dict.txt", "Lopadotemachoselachogaleokranioleipsanodrimhypotrimmatosilphioparaomelitokatakechymenokichlepikossyphophattoperisteralektryonoptekephalliokigklopeleiolagoiosiraiobaphetraganopterygon", "pet", 342},
 	}
-	testTrie = anagrambler.NewTrie()
+	testTrie = anagrambler.LoadDict(testData[0].dict)
 )
 
-func init() {
-	anagrambler.LoadDict(testTrie, testData[0].dict)
-}
-
 func testAnagramCount(t *testing.T, d dataItem) {
-	results := anagrambler.Search(testTrie, d.input, d.filter)
+	results := testTrie.Search(d.input, d.filter)
 
 	if len(results) == d.anagrams {
 		t.Logf("Success: found all %d expected anagrams for '%s' with filter '%s'\n", d.anagrams, d.input, d.filter)
@@ -57,14 +53,14 @@ func benchmarkFillTrie(b *testing.B, dictPath string) {
 		trie := anagrambler.NewTrie()
 
 		for _, word := range words {
-			anagrambler.AddWord(trie, word)
+			trie.AddWord(word)
 		}
 	}
 }
 
 func benchmarkSearch(b *testing.B, d dataItem) {
 	for counter := 0; counter < b.N; counter++ {
-		anagrambler.Search(testTrie, d.input, d.filter)
+		testTrie.Search(d.input, d.filter)
 	}
 }
 

--- a/cmd/anagrambler/main.go
+++ b/cmd/anagrambler/main.go
@@ -8,7 +8,7 @@ import (
 )
 
 func main() {
-	trie := anagrambler.NewNode()
+	trie := anagrambler.NewTrie()
 
 	anagrambler.LoadDict(trie, "go-dict.txt")
 

--- a/cmd/anagrambler/main.go
+++ b/cmd/anagrambler/main.go
@@ -8,7 +8,7 @@ import (
 )
 
 func main() {
-	t := anagrambler.LoadDict("go-dict.txt")
+	t := anagrambler.Open("go-dict.txt")
 
 	if len(os.Args) > 1 {
 		searchWord := os.Args[1]

--- a/cmd/anagrambler/main.go
+++ b/cmd/anagrambler/main.go
@@ -8,9 +8,7 @@ import (
 )
 
 func main() {
-	trie := anagrambler.NewTrie()
-
-	anagrambler.LoadDict(trie, "go-dict.txt")
+	t := anagrambler.LoadDict("go-dict.txt")
 
 	if len(os.Args) > 1 {
 		searchWord := os.Args[1]
@@ -21,7 +19,7 @@ func main() {
 			filter = os.Args[2]
 		}
 
-		results := anagrambler.Search(trie, searchWord, filter)
+		results := t.Search(searchWord, filter)
 
 		fmt.Println("Number of anagrams:", len(results))
 

--- a/cmd/anagrambler/main.go
+++ b/cmd/anagrambler/main.go
@@ -8,7 +8,14 @@ import (
 )
 
 func main() {
-	t := anagrambler.Open("go-dict.txt")
+	dictPath := "go-dict.txt"
+
+	t, err := anagrambler.Open(dictPath)
+
+	if err != nil {
+		fmt.Println("ERROR: Could not open dictionary file", dictPath)
+		os.Exit(1)
+	}
 
 	if len(os.Args) > 1 {
 		searchWord := os.Args[1]


### PR DESCRIPTION
These changes clean up the exported API a bit by introducing a Trie struct to contain the root node, and hold the Add and Search methods. It also renames some funcs, and adds rudimentary error support for Open().

It's not necessary, but I hope it will make the library easier to work with.
