### PR TITLE
Replace strings with byte slices everywhere

### DIFF
--- a/anagrambler.go
+++ b/anagrambler.go
@@ -42,7 +42,8 @@ func Open(filepath string) (*Trie, error) {
 	words = words[:len(words)-1]
 
 	for _, word := range words {
-		t.add(word)
+		sortedWord := sortWord(bytes.ToLower(word))
+		t.add(word, sortedWord)
 	}
 
 	return t, nil
@@ -51,7 +52,10 @@ func Open(filepath string) (*Trie, error) {
 // Exported Methods
 
 func (t *Trie) Add(word string) {
-	t.add([]byte(word))
+
+	sortedWord := sortWord(bytes.ToLower([]byte(word)))
+
+	t.add([]byte(word), sortedWord)
 }
 
 
@@ -75,10 +79,8 @@ func (t *Trie) Search(text string, filter string) []string {
 	return filteredResults
 }
 
-func (t *Trie) add(word []byte) {
+func (t *Trie) add(word, sortedWord []byte) {
 	path := t.root
-
-	sortedWord := sortWord(bytes.ToLower(word))
 
 	for i, w := 0, 0; i < len(sortedWord); i += w {
 		r, width := utf8.DecodeRune(sortedWord[i:])

--- a/anagrambler.go
+++ b/anagrambler.go
@@ -42,7 +42,9 @@ func Open(filepath string) (*Trie, error) {
 	words = words[:len(words)-1]
 
 	for _, word := range words {
-		sortedWord := sortWord(bytes.ToLower(word))
+		sortedWord := make([]byte, len(word))
+		copy(sortedWord, word)
+		sortWord(sortedWord)
 		t.add(word, sortedWord)
 	}
 
@@ -53,7 +55,9 @@ func Open(filepath string) (*Trie, error) {
 
 func (t *Trie) Add(word string) {
 
-	sortedWord := sortWord(bytes.ToLower([]byte(word)))
+	sortedWord := make([]byte, len(word))
+	copy(sortedWord, word)
+	sortWord(sortedWord)
 
 	t.add([]byte(word), sortedWord)
 }
@@ -62,7 +66,14 @@ func (t *Trie) Add(word string) {
 func (t *Trie) Search(text string, filter string) []string {
 	results := make(map[*node]bool)
 
-	sortedText, sortedFilter := sortWord(bytes.ToLower([]byte(text))), sortWord(bytes.ToLower([]byte(filter)))
+	sortedText := make([]byte, len(text))
+	sortedFilter := make([]byte, len(filter))
+
+	copy(sortedText, text)
+	copy(sortedFilter, filter)
+
+	sortWord(sortedText)
+	sortWord(sortedFilter)
 
 	search(t.root, sortedText, sortedFilter, results)
 

--- a/anagrambler_test.go
+++ b/anagrambler_test.go
@@ -19,12 +19,12 @@ type dataItem struct {
 // Test data and test fixtures
 var (
 	testData = []dataItem{
-		{"go-dict.txt", "honorificabilitudinitatibus", "", 9083},
-		{"go-dict.txt", "honorificabilitudinitatibus", "bus", 34},
-		{"go-dict.txt", "pneumonoultramicroscopicsilicovolcanoconiosis", "", 26035},
+		{"go-dict.txt", "honorificabilitudinitatibus", "", 7214},
+		{"go-dict.txt", "honorificabilitudinitatibus", "bus", 29},
+		{"go-dict.txt", "pneumonoultramicroscopicsilicovolcanoconiosis", "", 22090},
 		{"go-dict.txt", "pneumonoultramicroscopicsilicovolcanoconiosis", "ultra", 24},
-		{"go-dict.txt", "Lopadotemachoselachogaleokranioleipsanodrimhypotrimmatosilphioparaomelitokatakechymenokichlepikossyphophattoperisteralektryonoptekephalliokigklopeleiolagoiosiraiobaphetraganopterygon", "", 112436},
-		{"go-dict.txt", "Lopadotemachoselachogaleokranioleipsanodrimhypotrimmatosilphioparaomelitokatakechymenokichlepikossyphophattoperisteralektryonoptekephalliokigklopeleiolagoiosiraiobaphetraganopterygon", "pet", 342},
+		{"go-dict.txt", "Lopadotemachoselachogaleokranioleipsanodrimhypotrimmatosilphioparaomelitokatakechymenokichlepikossyphophattoperisteralektryonoptekephalliokigklopeleiolagoiosiraiobaphetraganopterygon", "", 98616},
+		{"go-dict.txt", "Lopadotemachoselachogaleokranioleipsanodrimhypotrimmatosilphioparaomelitokatakechymenokichlepikossyphophattoperisteralektryonoptekephalliokigklopeleiolagoiosiraiobaphetraganopterygon", "pet", 318},
 	}
 	testTrie *anagrambler.Trie
 )

--- a/anagrambler_test.go
+++ b/anagrambler_test.go
@@ -48,6 +48,15 @@ func testAnagramCount(t *testing.T, d dataItem) {
 	}
 }
 
+func benchmarkOpen(b *testing.B, dictPath string) {
+	for counter := 0; counter < b.N; counter++ {
+		_, err := anagrambler.Open(dictPath)
+		if err != nil {
+			panic(err)
+		}
+	}
+}
+
 func benchmarkFillTrie(b *testing.B, dictPath string) {
 	data, err := ioutil.ReadFile(dictPath)
 
@@ -83,6 +92,8 @@ func TestAngaramCountLongFilter(t *testing.T)     { testAnagramCount(t, testData
 
 // Benchmarks for loading a dictionary file into a trie.
 func BenchmarkFillTrie(b *testing.B) { benchmarkFillTrie(b, testData[0].dict) }
+
+func BenchmarkOpen(b *testing.B) { benchmarkOpen(b, testData[0].dict) }
 
 // Benchmarks for searching for anagrams.
 func BenchmarkSearchShort(b *testing.B)          { benchmarkSearch(b, testData[0]) }


### PR DESCRIPTION
NOTE: Also, stop lowercasing dictionary data. See below.

Before, we were converting the dictionary from []byte to string and then sorting and splitting it. Many allocs, splits, joins.

Now we keep everything as []byte. Since we've moved from strings to []bytes, we can't just range over the strings to step through the UTF-8 code points. Now we step through the slices by decoding the runes one at a time using utf8.DecodeRune().

It still makes sense for the external API for Add() to accept just a string arg, so meat of that function has been moved to an internal add().

add() doesn't create the sorted word itself, to allow Open() the ability to take potentially more efficient steps to allocating, copying and sorting the dictionary data all at once.

The sorting method used is the built-in sort.Sort(), but this is not necessarily the most efficient. Testing elsewhere indicates that an in-place Shell sort with the right parameters could be much faster. This isn't worth exploring now, however, since benchmarking on my machine indicates that of the ~1.2s of Open() time, only about 50ms are spent sorting.

**Lowercasing**

This also stops lowercasing the dictionary data as we add it. Case folding is a bit of a complicated topic, and Scrabble contains very specific, limited character sets. We shouldn't make assumptions about changing the input data; instead, we should just use data appropriate for our puprpose.

The data currently in the repo in use for testing isn't appropriate. We need to fix that at some point.
